### PR TITLE
Add: Estructura de modulos en GO para Notegram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ venv.bak/
 .mypy_cache/
 
 *~
+
+# Go Language convention
+bin/
+pkg/

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -1,0 +1,24 @@
+/*
+ * Notegram / CORE
+ * Paquete de logica interna del bot
+ */
+
+package core
+
+import (
+   "Notegram/data"
+   "Notegram/tg"
+)
+
+type NotegramError struct {
+   msg string
+}
+
+// Ejemplo: NotegramError.Error("Invalid Api Key")
+
+
+func CoreHello() string {
+   return "Hello from Core package AND " + data.DataHello() + " AND " + tg.TgHello()
+}
+
+

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -13,8 +13,9 @@ import (
 type NotegramError struct {
    msg string
 }
-
-// Ejemplo: NotegramError.Error("Invalid Api Key")
+func (ee *NotegramError) Error() string {
+    return ee.msg
+}
 
 
 func CoreHello() string {

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -1,0 +1,19 @@
+/*
+ * Notegram / data
+ * Paquete de interfaz con la base de datos
+ */
+
+package data
+
+type DataError struct {
+   msg string
+}
+
+// Ejemplo: DataError.Error("No se puede conectar a la BBDD")
+
+
+func DataHello() string {
+   return "Hello from Data package"
+}
+
+

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -9,8 +9,9 @@ type DataError struct {
    msg string
 }
 
-// Ejemplo: DataError.Error("No se puede conectar a la BBDD")
-
+func (ee *DataError) Error() string {
+    return ee.msg
+}
 
 func DataHello() string {
    return "Hello from Data package"

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,3 @@
+module Notegram
+
+go 1.16

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
    telegram "Notegram/tg"
 )
 
+
 func main() {
 
    fmt.Println("main function")

--- a/src/main.go
+++ b/src/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+   "fmt"
+   "Notegram/core"
+   "Notegram/data"
+   telegram "Notegram/tg"
+)
+
+func main() {
+
+   fmt.Println("main function")
+   fmt.Println(core.CoreHello())
+   fmt.Println(data.DataHello())
+   fmt.Println(telegram.TgHello())
+
+}
+
+

--- a/src/tg/tg.go
+++ b/src/tg/tg.go
@@ -1,0 +1,19 @@
+/*
+ * Notegram / tg
+ * Paquete de interfaz con Telegram
+ */
+
+package tg
+
+type TelegramError struct {
+   msg string
+}
+
+// Ejemplo: TelegramError.Error("Invalid Api Key")
+
+
+func TgHello() string {
+   return "Hello from TG Package"
+}
+
+

--- a/src/tg/tg.go
+++ b/src/tg/tg.go
@@ -5,12 +5,14 @@
 
 package tg
 
+// Nota: Habría que llevar un conteo de tipos de error etc...
 type TelegramError struct {
    msg string
 }
 
-// Ejemplo: TelegramError.Error("Invalid Api Key")
-
+func (ee *TelegramError) Error() string {
+    return ee.msg
+}
 
 func TgHello() string {
    return "Hello from TG Package"


### PR DESCRIPTION
- Tres módulos core (lógica interna), tg (interfaz con telegram), y data (base de datos)
- Se definen errores en core, tg, y data
- Desde hello.go y core/core.go se ve cómo se accede a los otros módulos
- Gitignore no hace caso de los directorios pkg y bin
- Closes Notegram #31 (if aproved)