### PR TITLE
Bot con funcionalidad mínima (echo - repite todo lo que recibe)

### DIFF
--- a/agil.yaml
+++ b/agil.yaml
@@ -16,4 +16,9 @@ taskfile:
 linter:
     - go vet
 
+tests:
+    - core/core_test.go
+
+aserciones: "@test"
+
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -22,6 +22,17 @@ BINDIR=$PWD/bin
 cd src ; go vet Notegram Notegram/core Notegram/tg Notegram/data
 ~~~
 
+## depend
+
+> Instala dependencias
+
+~~~sh
+echo "Instalando dependencias"
+BINDIR=$PWD/bin
+cd src ; go get github.com/go-telegram-bot-api/telegram-bot-api
+~~~
+
+
 ## hello
 
 > Just say jellow

--- a/maskfile.md
+++ b/maskfile.md
@@ -33,6 +33,14 @@ cd src ; go get github.com/go-telegram-bot-api/telegram-bot-api
 ~~~
 
 
+## test
+
+> Pasa los test del proyecto
+~~~sh
+cd src ; go test ./...
+~~~
+
+
 ## hello
 
 > Just say jellow

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 )
 
 type NotegramError struct {
@@ -50,7 +51,7 @@ func GetConfig(jsonfilename string) (NotegramConfig, error) {
 	jsconfig, ee := ioutil.ReadFile(jsonfilename)
 
 	if ee != nil {
-		fmt.Println("No se ha podido leer el fichero config.json")
+		log.Printf("No se ha podido leer el fichero %s", jsonfilename)
 		return conf, ee
 	}
 

--- a/src/core/core_test.go
+++ b/src/core/core_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"testing"
+)
+
+// Core function testing
+
+func Test_ConfigFileNotFound(t *testing.T) {
+
+	_, err := GetConfig("/this/filename/does/not/exist/even/if/you/are/root/.yeison")
+
+	if err == nil {
+		t.Error("No se deberia encontrar un fichero con un nombre tan raro")
+	}
+
+}
+
+func Test_InvalidJsonFile(t *testing.T) {
+
+	_, err1 := GetConfig("testdata/malformed_config.json")
+	_, err2 := GetConfig("testdata/malformed_config.txt")
+	_, err3 := GetConfig("testdata/malformed_config2.json")
+	// _, err4 := GetConfig("testdata/valid_config.json")
+
+	errlist := []error{err1, err2, err3}
+	for _, ee := range errlist {
+		if ee == nil {
+			t.Error("Check Kaputt. Deberias tener un error al leer ficheros JSON de configuracion txungos")
+		}
+	}
+
+}

--- a/src/core/testdata/malformed_config.json
+++ b/src/core/testdata/malformed_config.json
@@ -1,0 +1,9 @@
+{
+"secret": "telegram_secret",
+"dbhost":"123.34.45.56",
+"dbport": 27017, 
+"dbuser": "scott",
+"dbpass": "tiger",
+"dbcollection": "notegram"
+"loglevel": "Debug"
+}

--- a/src/core/testdata/malformed_config.txt
+++ b/src/core/testdata/malformed_config.txt
@@ -1,0 +1,1 @@
+Esto no es un fichero de test

--- a/src/core/testdata/malformed_config2.json
+++ b/src/core/testdata/malformed_config2.json
@@ -1,0 +1,9 @@
+{
+"secret": "telegram_secret",
+"dbhost":"123.34.45.56",
+"dbport": 27017, 
+"dbuser": "scott",
+"dbpass": "tiger",
+"dbcollection": "notegram",
+"loglevel": "Debug"
+

--- a/src/core/testdata/valid_config.json
+++ b/src/core/testdata/valid_config.json
@@ -1,0 +1,9 @@
+{
+"secret": "telegram_secret",
+"dbhost":"123.34.45.56",
+"dbport": 27017, 
+"dbuser": "scott",
+"dbpass": "tiger",
+"dbcollection": "notegram",
+"loglevel": "Debug"
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,8 @@
 module Notegram
 
 go 1.16
+
+require (
+	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible // indirect
+	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
+)

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,9 @@ func main() {
 		fmt.Print(botconfig)
 	}
 
+        telegram.StartBot(botconfig.Secret)
+
+
 	fmt.Println("main function")
 	fmt.Println(core.CoreHello())
 	fmt.Println(data.DataHello())

--- a/src/main.go
+++ b/src/main.go
@@ -5,15 +5,21 @@ import (
 	"Notegram/data"
 	telegram "Notegram/tg"
 	"fmt"
+        "flag"
 )
 
 func main() {
+
+        // Command line arguments -f config_file_path
+
+        configFilePtr := flag.String("f","config.json", "Path to config file")
+        flag.Parse()
 
 	// Bootstrap notegram
 	// Obtiene datos de configuracion del fichero.
 	// OJO: Algunos datos de la configuracion pueden ser sensibles!
 
-	botconfig, err := core.GetConfig("config.json")
+	botconfig, err := core.GetConfig(*configFilePtr)
 
 	if err != nil {
 		fmt.Println("Configuration summary:")

--- a/src/tg/tg.go
+++ b/src/tg/tg.go
@@ -5,6 +5,11 @@
 
 package tg
 
+import (
+    "fmt"
+    tg_botapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
 // Nota: Habría que llevar un conteo de tipos de error etc...
 type TelegramError struct {
    msg string
@@ -18,4 +23,31 @@ func TgHello() string {
    return "Hello from TG Package"
 }
 
+// tg.Startbot()
+// Ejecuta el bot a partir de la configuracion
 
+func StartBot(secret string) {
+
+   bot, err := tg_botapi.NewBotAPI(secret)
+
+   if err != nil {
+	fmt.Print("Err: " + err.Error())
+   }
+
+   fmt.Println("Bot Name: " + bot.Self.FirstName)
+
+   updates, err := bot.GetUpdatesChan(tg_botapi.NewUpdate(0))
+
+   for uu := range updates {
+
+      if uu.Message != nil {
+		fmt.Println("Update: " + uu.Message.Text)
+		// Devuelve el mensaje (echo server)
+		sendmsg := tg_botapi.NewMessage(uu.Message.Chat.ID, "> "+uu.Message.Text)
+		sendmsg.ParseMode = "markdown"
+		bot.Send(sendmsg)
+	}
+
+   }
+
+}


### PR DESCRIPTION
Implementado un bot mínimo:

- Toma la configuracion del fichero ./config.json
- Se le puede pasar otro fichero de configuración con el flag -f `path_al_fichero.json`
- El bot repite los mensajes que recibe (echo bot - repite como un loro)
- Listo para hacer test. Si hay problemas, salta por los aires con un SIGSEGV