### PR TITLE
Fix: agil.yaml Eliminados '-' en las entradas de testing

### DIFF
--- a/agil.yaml
+++ b/agil.yaml
@@ -22,8 +22,7 @@ test:
 aserciones: "@test"
 
 testing:
-    - runner: mask
-    - framework: go
-
+    runner: mask
+    framework: go
 
 


### PR DESCRIPTION
En testing tenemos que pasar un hashi/dict (clave/valor), no un array de hashes.
(Por algo JJ recomienda usar alguna herramienta para el yaml ;-)).

- Fixes error 'Not a HASH reference at proyecto.t line 35588.' en test del hito10