### PR TITLE
Hito 12 :balloon: :tada: :tada: :100: 

### DIFF
--- a/agil.yaml
+++ b/agil.yaml
@@ -25,4 +25,6 @@ testing:
     runner: mask
     framework: go
 
+# Interfaz dateador (abstrae el acceso a la BBDD para inyectar dependencias)
+dateador: data/data.go
 

--- a/core/core.go
+++ b/core/core.go
@@ -6,7 +6,6 @@
 package core
 
 import (
-	"Notegram/data"
 	"Notegram/tg"
 	"encoding/json"
 	"fmt"
@@ -26,13 +25,14 @@ func (ee *NotegramError) Error() string {
 // si no, el paquete encoding/json no puede verlos, y no emite ningún error.
 
 type NotegramConfig struct {
-	Secret       string
-	Dbhost       string
-	Dbport       uint
-	Dbuser       string
-	Dbpass       string
-	Dbcollection string
-	Loglevel     string
+	Secret       string // Telegram secret
+	Dbhost       string // mongodb hostname/ip
+	Dbport       uint   // mongodb port
+	Dbuser       string // mongodb username
+	Dbpass       string // mongodb passwd
+	Dbase        string // mongodb database
+	Dbcollection string // mongodb collection
+	Loglevel     string // loglevel
 }
 
 /*
@@ -68,5 +68,5 @@ func GetConfig(jsonfilename string) (NotegramConfig, error) {
 }
 
 func CoreHello() string {
-	return "Hello from Core package AND " + data.DataHello() + " AND " + tg.TgHello()
+	return "Hello from Core package AND tg/" + tg.TgHello()
 }

--- a/core/testdata/config_sample.json
+++ b/core/testdata/config_sample.json
@@ -4,7 +4,6 @@
 "dbport": 27017, 
 "dbuser": "scott",
 "dbpass": "tiger",
-"database": "notegram"
-"dbcollection": "notas",
+"dbcollection": "notegram",
 "loglevel": "Debug"
 }

--- a/data/data.go
+++ b/data/data.go
@@ -6,15 +6,13 @@
 package data
 
 type DataError struct {
-   msg string
+	msg string
 }
 
 func (ee *DataError) Error() string {
-    return ee.msg
+	return ee.msg
 }
 
 func DataHello() string {
-   return "Hello from Data package"
+	return "Hello from Data package"
 }
-
-

--- a/data/data.go
+++ b/data/data.go
@@ -5,14 +5,108 @@
 
 package data
 
+import (
+	"Notegram/core"
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
 type DataError struct {
 	msg string
+}
+
+type NotegramConnection struct {
+	mongocli     *mongo.Client // Cliente de la base de datos
+	database     string        // Where data is stored
+	dbcollection string        // Collection en la que buscamos
+	tguser       string        // Usuario de telegram
+	lastnote     string        // cache
+	ctx          context.Context
+}
+
+type Notes struct {
+	Id              primitive.ObjectID `bson:"_id"`
+	User            string             `bson:user`
+	Content         string             `bson:"content"`
+	ContentType     string             `bson:"content_type"`
+	ContentEncoding string             `bson:"content_encoding.ifpresent`
+}
+
+// ConnectToDatabase: Conecta y hace ping al servidor
+// config.Connect() <-- Esta pidiendo esto ;-)
+func ConnectToDatabase(config core.NotegramConfig) (NotegramConnection, error) {
+
+	var dc NotegramConnection
+
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	// was: ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// defer cancel()
+
+	var connURI string = fmt.Sprintf("mongodb://%s:%s@%s:%d/%s",
+		config.Dbuser,
+		config.Dbpass,
+		config.Dbhost,
+		config.Dbport,
+		config.Dbase)
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURI))
+
+	// Necesitamos esto para hacer un find
+	dc.mongocli = client
+	dc.dbcollection = config.Dbcollection
+	dc.database = config.Dbase
+	dc.ctx = ctx // Necesitamos el context para llamar a mongodb
+
+	err = client.Ping(ctx, nil)
+
+	return dc, err
+}
+
+func (conn NotegramConnection) Disconnect() {
+	conn.mongocli.Disconnect(conn.ctx)
+	conn.mongocli = nil
+	conn.ctx = nil
+}
+
+// Interfaz CRUD
+
+func (conn NotegramConnection) GetNotas(userid string) []Notes {
+
+	// Hay notas ???
+
+	var notas []Notes
+
+	db := conn.mongocli.Database(conn.database)
+	coll := db.Collection(conn.dbcollection)
+
+	err := coll.FindOne(conn.ctx, bson.M{"_id": userid}).Decode(&notas)
+
+	fmt.Println(err)
+
+	return notas
+
+}
+
+func WriteNotaUser(config NotegramConnection, username string, nota string) error {
+
+	// Primero obtenemos todas las notas
+	// Si no hay notas, escribimos una entrada en la collection para ese usuario con una nota
+	// Si hay notas escribimos una más.
+
+	panic("Not implemented")
+
 }
 
 func (ee *DataError) Error() string {
 	return ee.msg
 }
 
+// deprecated
 func DataHello() string {
 	return "Hello from Data package"
 }

--- a/data/data.go
+++ b/data/data.go
@@ -7,6 +7,7 @@ package data
 
 import (
 	"Notegram/core"
+	"log"
 )
 
 type DataError struct {
@@ -21,15 +22,54 @@ type Notes struct {
 	ContentEncoding string `bson:"content_encoding.ifpresent"`
 }
 
+type NotegramStorage struct {
+	storage Dateador
+}
+
 // Interfaz dateador para hacer inyección de dependencias
 type Dateador interface {
 	ConnectToDatabase(core.NotegramConfig) (Dateador, error)
 	Disconnect()
 	GetNotas(userid string) ([]Notes, error)
 	WriteNota(nota Notes) error
-	DeleteNotaByID(id string)
+	DeleteNotaByID(id string) error
 }
 
 func (ee *DataError) Error() string {
 	return ee.msg
+}
+
+func (ns NotegramStorage) ConnectToDatabase(config core.NotegramConfig) (Dateador, error) {
+	return ns.storage.ConnectToDatabase(config)
+}
+
+func (dt NotegramStorage) Disconnect() {
+	dt.Disconnect()
+}
+
+func (dt NotegramStorage) GetNotas(user string) ([]Notes, error) {
+	result, err := dt.storage.GetNotas(user)
+
+	if err != nil {
+		log.Print("GetNotas: No se pudo realizar la operación ", err)
+		return nil, err
+	}
+
+	return result, err
+}
+
+func (dt NotegramStorage) WriteNota(nota Notes) error {
+	err := dt.storage.WriteNota(nota)
+	if err != nil {
+		log.Print("WriteNota: no se pudo escribir la nota ", err)
+	}
+	return dt.WriteNota(nota)
+}
+
+func (dt NotegramStorage) DeleteNotaByID(id string) error {
+	err := dt.storage.DeleteNotaByID(id)
+	if err != nil {
+		log.Printf("DeleteNota: no se pudo borrar la nota con id=%s %s", id, err)
+	}
+	return err
 }

--- a/data/data.go
+++ b/data/data.go
@@ -21,6 +21,15 @@ type DataError struct {
 	msg string
 }
 
+// Interfaz dateador para hacer inyección de dependencias
+type Dateador interface {
+	ConnectToDatabase(core.NotegramConfig) (Dateador, error)
+	Disconnect()
+	GetNotas(userid string) ([]Notes, error)
+	WriteNota(nota Notes) error
+	DeleteNotaByID(id string)
+}
+
 type NotegramConnection struct {
 	mongocli     *mongo.Client // Cliente de la base de datos
 	database     string        // Where data is stored
@@ -45,7 +54,7 @@ func ConnectToDatabase(config core.NotegramConfig) (NotegramConnection, error) {
 	var dc NotegramConnection
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel() 
+	defer cancel()
 
 	var connURI string = fmt.Sprintf("mongodb://%s:%s@%s:%d/%s",
 		config.Dbuser,
@@ -68,7 +77,7 @@ func ConnectToDatabase(config core.NotegramConfig) (NotegramConnection, error) {
 func (conn NotegramConnection) Disconnect() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel() 
+	defer cancel()
 
 	conn.mongocli.Disconnect(ctx)
 	conn.mongocli = nil
@@ -79,7 +88,7 @@ func (conn NotegramConnection) Disconnect() {
 func (conn NotegramConnection) GetNotas(userid string) ([]Notes, error) {
 	var notas []Notes
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel() 
+	defer cancel()
 
 	db := conn.mongocli.Database(conn.database)
 	coll := db.Collection(conn.dbcollection)
@@ -95,7 +104,7 @@ func (conn NotegramConnection) WriteNota(nota Notes) error {
 	db := conn.mongocli.Database(conn.database)
 	coll := db.Collection(conn.dbcollection)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel() 
+	defer cancel()
 	_, err := coll.InsertOne(ctx, &nota)
 	return err
 }
@@ -106,7 +115,7 @@ func (conn NotegramConnection) DeleteNotaByID(id primitive.ObjectID) error {
 	db := conn.mongocli.Database(conn.database)
 	coll := db.Collection(conn.dbcollection)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel() 
+	defer cancel()
 	_, err := coll.DeleteOne(ctx, bson.M{"_id": id})
 	return err
 }

--- a/data/data.go
+++ b/data/data.go
@@ -7,18 +7,18 @@ package data
 
 import (
 	"Notegram/core"
-	"context"
-	"fmt"
-	"time"
-
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type DataError struct {
 	msg string
+}
+
+type Notes struct {
+	Id              string `bson:"-"`
+	User            string `bson:"user"`
+	Content         string `bson:"content"`
+	ContentType     string `bson:"content_type"`
+	ContentEncoding string `bson:"content_encoding.ifpresent"`
 }
 
 // Interfaz dateador para hacer inyección de dependencias
@@ -28,96 +28,6 @@ type Dateador interface {
 	GetNotas(userid string) ([]Notes, error)
 	WriteNota(nota Notes) error
 	DeleteNotaByID(id string)
-}
-
-type NotegramConnection struct {
-	mongocli     *mongo.Client // Cliente de la base de datos
-	database     string        // Where data is stored
-	dbcollection string        // Collection en la que buscamos
-	tguser       string        // Usuario de telegram
-	lastnote     string        // cache
-	// unused // ctx          context.Context
-}
-
-type Notes struct {
-	Id              primitive.ObjectID `bson:"_id,omitempty"`
-	User            string             `bson:"user"`
-	Content         string             `bson:"content"`
-	ContentType     string             `bson:"content_type"`
-	ContentEncoding string             `bson:"content_encoding.ifpresent"`
-}
-
-// ConnectToDatabase: Conecta y hace ping al servidor
-// config.Connect() <-- Esta pidiendo una interfaz como esta ;-)
-func ConnectToDatabase(config core.NotegramConfig) (NotegramConnection, error) {
-
-	var dc NotegramConnection
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	var connURI string = fmt.Sprintf("mongodb://%s:%s@%s:%d/%s",
-		config.Dbuser,
-		config.Dbpass,
-		config.Dbhost,
-		config.Dbport,
-		config.Dbase)
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURI))
-
-	// Completamos la estructura para llamadas siguientes
-	dc.mongocli = client
-	dc.dbcollection = config.Dbcollection
-	dc.database = config.Dbase
-
-	err = client.Ping(ctx, nil)
-
-	return dc, err
-}
-
-func (conn NotegramConnection) Disconnect() {
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	conn.mongocli.Disconnect(ctx)
-	conn.mongocli = nil
-}
-
-// Interfaz CRUD
-
-func (conn NotegramConnection) GetNotas(userid string) ([]Notes, error) {
-	var notas []Notes
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	db := conn.mongocli.Database(conn.database)
-	coll := db.Collection(conn.dbcollection)
-	cursor, err := coll.Find(ctx, bson.M{"user": userid})
-	err = cursor.All(ctx, &notas)
-
-	return notas, err
-}
-
-// WriteNota(nota)
-// Escribe una nota en la BBDD mongodb.
-func (conn NotegramConnection) WriteNota(nota Notes) error {
-	db := conn.mongocli.Database(conn.database)
-	coll := db.Collection(conn.dbcollection)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_, err := coll.InsertOne(ctx, &nota)
-	return err
-}
-
-// DeleteNotaById(id)
-// Borra la nota con el ID de mensaje pasada como argumento
-func (conn NotegramConnection) DeleteNotaByID(id primitive.ObjectID) error {
-	db := conn.mongocli.Database(conn.database)
-	coll := db.Collection(conn.dbcollection)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_, err := coll.DeleteOne(ctx, bson.M{"_id": id})
-	return err
 }
 
 func (ee *DataError) Error() string {

--- a/data/data_memory.go
+++ b/data/data_memory.go
@@ -1,0 +1,65 @@
+/*
+ * Notegram / data_memory
+ * Interfaz de almacenamiento de BBDD en memoria para testing.
+ * Sólo tenemos una nota en memoria (y de un único usuario).
+ */
+
+package data
+
+import (
+	"Notegram/core"
+	"fmt"
+)
+
+type DateadorInMemory struct {
+	Numnotas int   // numnotas
+	Nota     Notes // solo tenemos una nota
+	Dateador
+}
+
+// Constructor
+
+func NewBackendInMemory() Dateador {
+	var dd DateadorInMemory
+	dd.Numnotas = 0
+	return &dd
+}
+
+// Interfaz dateador
+
+func (d *DateadorInMemory) ConnectToDatabase(c core.NotegramConfig) (Dateador, error) {
+	d.Numnotas = 0
+	return d, nil
+}
+
+func (d *DateadorInMemory) Disconnect() {
+	d.Numnotas = 0
+}
+
+func (d *DateadorInMemory) GetNotas(user string) ([]Notes, error) {
+	var retval []Notes
+
+	if d.Numnotas > 0 && user == d.Nota.User {
+		retval = append(retval, d.Nota)
+		fmt.Print(len(retval))
+		fmt.Printf("GetNotas() returns -> %v\n", d.Nota)
+		fmt.Printf("Nota (interna) = %v, \n", d.Nota)
+	}
+
+	return retval, nil
+}
+
+func (d *DateadorInMemory) WriteNota(nota Notes) error {
+	d.Numnotas = 1
+	d.Nota = nota
+	fmt.Printf("Nota (interna) = %v, \n", d.Nota)
+
+	return nil
+}
+
+func (dt *DateadorInMemory) DeleteNotaByID(id string) error {
+	if dt.Nota.Id == id {
+		dt.Numnotas = 0
+	}
+	return nil
+}

--- a/data/data_mongodb.go
+++ b/data/data_mongodb.go
@@ -1,0 +1,158 @@
+/*
+ * Notegram / data
+ * Implementa la interfaz con MongoDB
+ */
+
+package data
+
+import (
+	"Notegram/core"
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Implementamos interfaz Dateador para almacenamiento de notas
+//
+// type Dateador interface {
+//	ConnectToDatabase(core.NotegramConfig) (Dateador, error)
+//	Disconnect()
+//	GetNotas(userid string) ([]Notes, error)
+//	WriteNota(nota Notes) error
+//	DeleteNotaByID(id string)
+// }
+
+type NotegramConnection struct {
+	mongocli     *mongo.Client // Cliente de la base de datos
+	database     string        // Where data is stored
+	dbcollection string        // Collection en la que buscamos
+	tguser       string        // Usuario de telegram
+	lastnote     string        // cache
+	// unused // ctx          context.Context
+}
+
+type NotesMongo struct {
+	mongoId primitive.ObjectID `bson:"_id,omitempty"`
+	Notes
+}
+
+func (n Notes) to_mongo() NotesMongo {
+	var nm NotesMongo
+	nm.Notes = n
+	fmt.Print("Calling: ", n)
+
+	oid, _ := primitive.ObjectIDFromHex(n.Id)
+	nm.mongoId = oid
+	fmt.Print(nm)
+
+	return nm // el compilador asigna nm en el heap, no en la pila???
+}
+
+// ConnectToDatabase: Conecta y hace ping al servidor
+// config.Connect() <-- Esta pidiendo una interfaz como esta ;-)
+func ConnectToDatabase(config core.NotegramConfig) (NotegramConnection, error) {
+
+	var dc NotegramConnection
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var connURI string = fmt.Sprintf("mongodb://%s:%s@%s:%d/%s",
+		config.Dbuser,
+		config.Dbpass,
+		config.Dbhost,
+		config.Dbport,
+		config.Dbase)
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURI))
+
+	// Completamos la estructura para llamadas siguientes
+	dc.mongocli = client
+	dc.dbcollection = config.Dbcollection
+	dc.database = config.Dbase
+
+	err = client.Ping(ctx, nil)
+
+	return dc, err
+}
+
+func (conn NotegramConnection) Disconnect() {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn.mongocli.Disconnect(ctx)
+	conn.mongocli = nil
+}
+
+// Interfaz CRUD
+
+func (conn NotegramConnection) GetNotas(userid string) ([]Notes, error) {
+	var retval []Notes
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	log.Printf("DEBUG GetNotas(%s)\n", userid)
+
+	db := conn.mongocli.Database(conn.database)
+	coll := db.Collection(conn.dbcollection)
+
+	filter := bson.M{"user": userid}
+
+	log.Printf("GetNotas - filter= %v\n", filter)
+	cursor, err := coll.Find(ctx, filter)
+
+	log.Printf("*****\ncoll.Find() ->\n\t cursor = r%+v, err %+v \n", cursor, err)
+
+	if err != nil {
+		log.Println("**************\n**********\n coll.Find() returned error -> ", err)
+	}
+	err = cursor.All(ctx, &retval)
+
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Getnotas(Userid = %s):\n\t Notasmongo = %+v", userid, retval)
+
+	return retval, err
+}
+
+// WriteNota(nota)
+// Escribe una nota en la BBDD mongodb.
+func (conn NotegramConnection) WriteNota(nota Notes) error {
+	db := conn.mongocli.Database(conn.database)
+	coll := db.Collection(conn.dbcollection)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := coll.InsertOne(ctx, &nota)
+	return err
+}
+
+// DeleteNotaById(id)
+// Borra la nota con el ID de mensaje pasada como argumento
+func (conn NotegramConnection) DeleteNotaByID(id string) error {
+
+	oid, err := primitive.ObjectIDFromHex(id)
+	if err == nil {
+		// Este error debería estar en el inventario
+		log.Print("Invalid id (must be 12byte hex string)")
+		return err
+	}
+
+	db := conn.mongocli.Database(conn.database)
+	coll := db.Collection(conn.dbcollection)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	res, err := coll.DeleteOne(ctx, bson.M{"_id": oid})
+
+	fmt.Print("Resultado borrado:", res)
+
+	return err
+}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -20,9 +20,20 @@ var cfg = core.NotegramConfig{
 	Loglevel:     "Debug",
 }
 
+func TestConnectInmemory(t *testing.T) {
+
+	dat := NewBackendInMemory()
+	d, err := dat.ConnectToDatabase(cfg)
+
+	fmt.Printf("dat: %v, d=%v, err=%v\n", dat, d, err)
+	fmt.Print("Dat == d -> ", (dat == d))
+
+}
+
 func TestConectaMongoDB(t *testing.T) {
 
-	conn, err := ConnectToDatabase(cfg)
+	dat := NewBackendInMemory()
+	conn, err := dat.ConnectToDatabase(cfg)
 	fmt.Println("conn: ", conn, " err: ", err)
 
 	// Para este test tenemos una bbdd en local con esas credenciales
@@ -35,33 +46,6 @@ func TestConectaMongoDB(t *testing.T) {
 	}
 
 	conn.Disconnect()
-
-}
-
-/*
- * TestFind() - Busca en la BBDD un registro de prueba
- * que incluimos en mask setupmongodb
- */
-
-func TestFind(t *testing.T) {
-
-	conn, err := ConnectToDatabase(cfg)
-	defer conn.Disconnect()
-
-	if err != nil {
-		// esto suena a integration test fallido
-		t.Error("TestFind(", cfg, ") FAILED wirt error ", err)
-	}
-
-	msgs, err := conn.GetNotas("test123")
-
-	if err != nil {
-		errmsg := "No se encuentra la entrada de test"
-		t.Error(errmsg)
-		log.Print(errmsg)
-	}
-
-	log.Print("Contenido de la BBDD: ", msgs)
 
 }
 
@@ -84,7 +68,10 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 		ContentEncoding: "utf8",
 	}
 
-	conn, err := ConnectToDatabase(cfg)
+	dat := NewBackendInMemory()
+	d, err := dat.ConnectToDatabase(cfg)
+	conn, err := d.ConnectToDatabase(cfg)
+
 	defer conn.Disconnect()
 
 	if err != nil {
@@ -95,6 +82,7 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	err = conn.WriteNota(newNote)
 
 	fmt.Println("Writenota() -> err = ", err)
+	fmt.Println("Writenota backend ", d)
 
 	regs, err := conn.GetNotas(testUsername)
 	if err != nil {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -7,8 +7,6 @@ import (
 	"math/rand"
 	"testing"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 var cfg = core.NotegramConfig{
@@ -81,9 +79,9 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	var testUsername = fmt.Sprintf("testuser_%020d", rand.Int63n(1000000000000000000))
 
 	var newNote = Notes{
-		Id:              primitive.NilObjectID,
+		Id:              "0x00000000",
 		User:            testUsername,
-		Content:         "This a string in UTF8 that can hold emoji 👏👏👏 + more contents.",
+		Content:         "👏👏👏  HELLO",
 		ContentType:     "text/plain",
 		ContentEncoding: "utf8",
 	}
@@ -95,11 +93,17 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	}
 
 	err = conn.WriteNota(newNote)
+
+	fmt.Println("Writenota() -> err = ", err)
+
 	regs, err := conn.GetNotas(testUsername)
 	if err != nil {
 		t.Error("TestWrite: Fallo al escribir en la BBDD")
-
 	}
+
+	fmt.Printf("TESTNOTAS: GetNotas(%s) = %+v\n", testUsername, regs)
+
+	fmt.Println("TESTNOTAS:\n\terr = ", err, "\n\t regs = ", regs, "len(regs)=", len(regs))
 
 	readNote := regs[len(regs)-1]
 	readDocid := readNote.Id
@@ -107,7 +111,7 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	log.Println("Registro escrito:\n\t", newNote)
 	log.Println("Registro leido:\n\t", readNote)
 
-	readNote.Id = primitive.NilObjectID
+	readNote.Id = "0x00000000"
 
 	if readNote != newNote {
 		t.Error("Las notas son diferentes -  escrito:", newNote, " leido: ", regs)
@@ -118,12 +122,14 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	err = conn.DeleteNotaByID(readDocid)
 
 	if err != nil {
-		t.Error("Error al borrar la nota con id: ", readDocid)
+		t.Errorf("Error al borrar la nota con id: %s", readDocid)
 	}
 
 	// Volvemos a buscar el registro
 
 	regs, err = conn.GetNotas(testUsername)
+
+	fmt.Println("TESTNOTAS:\n\terr = ", err, "\n\t regs = ")
 
 	if len(regs) != 0 {
 		log.Println("Se ha encontrado un registro que debería estar borrado")

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1,0 +1,134 @@
+package data
+
+import (
+	"Notegram/core"
+	"fmt"
+	"log"
+	"math/rand"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var cfg = core.NotegramConfig{
+	Secret:       "somesecret",
+	Dbhost:       "127.0.0.1",
+	Dbport:       27017,
+	Dbuser:       "scott",
+	Dbpass:       "tiger",
+	Dbase:        "notegram",
+	Dbcollection: "notas",
+	Loglevel:     "Debug",
+}
+
+func TestConectaMongoDB(t *testing.T) {
+	// notegramConfig, err := core.GetConfig("testdata/localhost.json")
+
+	conn, err := ConnectToDatabase(cfg)
+	fmt.Println("conn: ", conn, " err: ", err)
+
+	// Para este test tenemos una bbdd en local con esas credenciales
+	// o bien un dateador que nos "mockea" la conexion a mongo etc..
+
+	if err != nil {
+		// esto suena a integration test fallido
+		t.Error("ConnectToDatabase(", cfg, ") FAILED wirh error ", err)
+		t.FailNow()
+	}
+
+	//Disconnect(conn)
+
+	conn.Disconnect()
+
+}
+
+/*
+ * TestFind() - Busca en la BBDD un registro de prueba
+ * que incluimos en mask setupmongodb
+ */
+
+func TestFind(t *testing.T) {
+
+	conn, err := ConnectToDatabase(cfg)
+
+	if err != nil {
+		// esto suena a integration test fallido
+		t.Error("TestFind(", cfg, ") FAILED wirt error ", err)
+	}
+
+	msgs, err := conn.GetNotas("test123")
+
+	if err != nil {
+		errmsg := "No se encuentra la entrada de test"
+		t.Error(errmsg)
+		log.Print(errmsg)
+	}
+
+	log.Print("Contenido de la BBDD: ", msgs)
+
+}
+
+/*
+ * Comprobamos que funcionan las operaciones de la BBDD_
+ * almacenando y recuperando el mismo registro
+ */
+
+func TestMongoDBWriteReadDelete(t *testing.T) {
+
+	rand.Seed(time.Now().UnixNano())
+
+	var testUsername = fmt.Sprintf("testuser_%020d", rand.Int63n(1000000000000000000))
+
+	var newNote = Notes{
+		Id:              primitive.NilObjectID,
+		User:            testUsername,
+		Content:         "This a string in UTF8 that can hold emoji 👏👏👏 + more contents.",
+		ContentType:     "text/plain",
+		ContentEncoding: "utf8",
+	}
+
+	conn, err := ConnectToDatabase(cfg)
+	if err != nil {
+		// esto suena a integration test fallido
+		t.Error("TestWrite(", cfg, ") FAILED trying to connect to database", err)
+	}
+
+	err = conn.WriteNota(newNote)
+	regs, err := conn.GetNotas(testUsername)
+	if err != nil {
+		t.Error("TestWrite: Fallo al escribir en la BBDD")
+
+	}
+
+	readNote := regs[len(regs)-1]
+	readDocid := readNote.Id
+
+	log.Println("Registro escrito:\n\t", newNote)
+	log.Println("Registro leido:\n\t", readNote)
+
+	readNote.Id = primitive.NilObjectID
+
+	if readNote != newNote {
+		t.Error("Las notas son diferentes -  escrito:", newNote, " leido: ", regs)
+	}
+
+	// Borramos el registro y comprobamos que no existe al leerlo
+
+	err = conn.DeleteNotaByID(readDocid)
+
+	if err != nil {
+		t.Error("Error al borrar la nota con id: ", readDocid)
+	}
+
+	// Volvemos a buscar el registro
+
+	regs, err = conn.GetNotas(testUsername)
+
+	if len(regs) != 0 {
+		log.Println("Se ha encontrado un registro que debería estar borrado")
+	}
+
+	log.Println("Buscamos despues de borrar. Resultados: err=", err, "regs=", regs)
+
+}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -21,7 +21,6 @@ var cfg = core.NotegramConfig{
 }
 
 func TestConectaMongoDB(t *testing.T) {
-	// notegramConfig, err := core.GetConfig("testdata/localhost.json")
 
 	conn, err := ConnectToDatabase(cfg)
 	fmt.Println("conn: ", conn, " err: ", err)
@@ -35,8 +34,6 @@ func TestConectaMongoDB(t *testing.T) {
 		t.FailNow()
 	}
 
-	//Disconnect(conn)
-
 	conn.Disconnect()
 
 }
@@ -49,6 +46,7 @@ func TestConectaMongoDB(t *testing.T) {
 func TestFind(t *testing.T) {
 
 	conn, err := ConnectToDatabase(cfg)
+	defer conn.Disconnect()
 
 	if err != nil {
 		// esto suena a integration test fallido
@@ -87,6 +85,8 @@ func TestMongoDBWriteReadDelete(t *testing.T) {
 	}
 
 	conn, err := ConnectToDatabase(cfg)
+	defer conn.Disconnect()
+
 	if err != nil {
 		// esto suena a integration test fallido
 		t.Error("TestWrite(", cfg, ") FAILED trying to connect to database", err)

--- a/data/testdata/localhost.json
+++ b/data/testdata/localhost.json
@@ -1,10 +1,10 @@
 {
 "secret": "telegram_secret",
-"dbhost":"123.34.45.56",
+"dbhost":"127.0.0.1",
 "dbport": 27017, 
 "dbuser": "scott",
 "dbpass": "tiger",
-"database": "notegram"
+"database": "notegram",
 "dbcollection": "notas",
 "loglevel": "Debug"
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible // indirect
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -4,16 +4,16 @@ import (
 	"Notegram/core"
 	"Notegram/data"
 	telegram "Notegram/tg"
+	"flag"
 	"fmt"
-        "flag"
 )
 
 func main() {
 
-        // Command line arguments -f config_file_path
+	// Command line arguments -f config_file_path
 
-        configFilePtr := flag.String("f","config.json", "Path to config file")
-        flag.Parse()
+	configFilePtr := flag.String("f", "config.json", "Path to config file")
+	flag.Parse()
 
 	// Bootstrap notegram
 	// Obtiene datos de configuracion del fichero.
@@ -26,8 +26,7 @@ func main() {
 		fmt.Print(botconfig)
 	}
 
-        telegram.StartBot(botconfig.Secret)
-
+	telegram.StartBot(botconfig.Secret)
 
 	fmt.Println("main function")
 	fmt.Println(core.CoreHello())

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"Notegram/core"
-	"Notegram/data"
 	telegram "Notegram/tg"
 	"flag"
 	"fmt"
@@ -30,7 +29,6 @@ func main() {
 
 	fmt.Println("main function")
 	fmt.Println(core.CoreHello())
-	fmt.Println(data.DataHello())
 	fmt.Println(telegram.TgHello())
 
 }

--- a/maskfile.md
+++ b/maskfile.md
@@ -110,10 +110,10 @@ try {
 
 try {
    db.notas.insert({
-      _id: "test123",
-      notas: ["Primera nota", 
-           "Segunda nota",
-           "Tercera nota (con cacteres unicode 💩💩💩 )"]
+      user: "test123",
+      content: "Tercera nota (con cacteres unicode 💩💩💩 )",
+      content_type: "test/plain",
+      content_encoding: "utf8"
    });
 } catch (err) { print(err);}
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -83,3 +83,42 @@ for i in $(find . -name '*.go') ; do
    gofmt -s -w $i
 done
 ~~~
+
+## setupmongodb
+
+> Crea entorno de test/desarrollo en mongodb
+
+El entorno contiene:
+ - Usuario scott para crear / acceder a notas.
+ - Base de datos 'notegram'
+ - Collection "notegram.notas"l
+ - Crea una primera nota de ejemplo para que db.notas.find()
+
+~~~sh
+mongo -host localhost <<MONGO_EOF
+use notegram
+
+try {
+   db.createUser({user:"scott", 
+               pwd:"tiger",
+               roles: [ { role:"readWrite", db: "notegram"}] });
+} catch (err) { print(err);}
+
+try {
+   db.createCollection("notas");
+} catch (err) { print(err);}
+
+try {
+   db.notas.insert({
+      _id: "test123",
+      notas: ["Primera nota", 
+           "Segunda nota",
+           "Tercera nota (con cacteres unicode 💩💩💩 )"]
+   });
+} catch (err) { print(err);}
+
+print("Setup terminado");
+
+MONGO_EOF
+~~~
+

--- a/maskfile.md
+++ b/maskfile.md
@@ -73,3 +73,13 @@ for ff in files:
    print(f"Resultado:\n")
    pp.pprint(out)
 ~~~
+
+## gofmt
+
+> Formatea (todo) el código con gofmt
+
+~~~sh
+for i in $(find . -name '*.go') ; do
+   gofmt -s -w $i
+done
+~~~

--- a/maskfile.md
+++ b/maskfile.md
@@ -135,6 +135,13 @@ db.notas.deleteMany({});
 MONGO_EOF
 ~~~
 
+## dumpmongodb
+> Que carajo esta guardado en MONGODB ????
 
-B
+~~~sh
+mongo -host localhost <<MONGO_EOF
+use notegram
+
+db.notas.find({});
+
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -122,3 +122,19 @@ print("Setup terminado");
 MONGO_EOF
 ~~~
 
+## cleanmongodb
+
+> Borra contenido de la BBDD mongodb
+
+~~~sh
+mongo -host localhost <<MONGO_EOF
+use notegram
+
+db.notas.deleteMany({});
+
+MONGO_EOF
+~~~
+
+
+B
+

--- a/tg/tg.go
+++ b/tg/tg.go
@@ -6,21 +6,21 @@
 package tg
 
 import (
-    "fmt"
-    tg_botapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"fmt"
+	tg_botapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
 // Nota: Habría que llevar un conteo de tipos de error etc...
 type TelegramError struct {
-   msg string
+	msg string
 }
 
 func (ee *TelegramError) Error() string {
-    return ee.msg
+	return ee.msg
 }
 
 func TgHello() string {
-   return "Hello from TG Package"
+	return "Hello from TG Package"
 }
 
 // tg.Startbot()
@@ -28,26 +28,26 @@ func TgHello() string {
 
 func StartBot(secret string) {
 
-   bot, err := tg_botapi.NewBotAPI(secret)
+	bot, err := tg_botapi.NewBotAPI(secret)
 
-   if err != nil {
-	fmt.Print("Err: " + err.Error())
-   }
-
-   fmt.Println("Bot Name: " + bot.Self.FirstName)
-
-   updates, err := bot.GetUpdatesChan(tg_botapi.NewUpdate(0))
-
-   for uu := range updates {
-
-      if uu.Message != nil {
-		fmt.Println("Update: " + uu.Message.Text)
-		// Devuelve el mensaje (echo server)
-		sendmsg := tg_botapi.NewMessage(uu.Message.Chat.ID, "> "+uu.Message.Text)
-		sendmsg.ParseMode = "markdown"
-		bot.Send(sendmsg)
+	if err != nil {
+		fmt.Print("Err: " + err.Error())
 	}
 
-   }
+	fmt.Println("Bot Name: " + bot.Self.FirstName)
+
+	updates, err := bot.GetUpdatesChan(tg_botapi.NewUpdate(0))
+
+	for uu := range updates {
+
+		if uu.Message != nil {
+			fmt.Println("Update: " + uu.Message.Text)
+			// Devuelve el mensaje (echo server)
+			sendmsg := tg_botapi.NewMessage(uu.Message.Chat.ID, "> "+uu.Message.Text)
+			sendmsg.ParseMode = "markdown"
+			bot.Send(sendmsg)
+		}
+
+	}
 
 }


### PR DESCRIPTION
Habemos dateador.
Pasa test unitarios, cambiado el yaml....

Problema encontrado (de los feos):
   - El #@! driver de Mongodb no expone interfaces, así que no se puede inyectar dependencias.
   - Solución #1: Pasar test con un mongodb instalado... pero no funciona en travis.
   - Solucioón #2:  interfaz dateador en `data.go` y dos implementaciones. Una en memoria sencilla, y otra en mongodb.
  